### PR TITLE
Allow caching multiple sizes of image files

### DIFF
--- a/library/src/main/java/com/baasbox/android/AsyncStream.java
+++ b/library/src/main/java/com/baasbox/android/AsyncStream.java
@@ -48,7 +48,7 @@ abstract class AsyncStream<R> extends NetworkTask<R> {
     protected R getFromCache(BaasBox box) throws BaasException {
         boolean handle = false;
         try {
-            byte[] bytes = box.mCache.get(streamId());
+            byte[] bytes = box.mCache.get(cacheKey());
             if (bytes == null) {
                 Logger.info("GOT FROM CACHE MISS");
                 return null;
@@ -67,6 +67,10 @@ abstract class AsyncStream<R> extends NetworkTask<R> {
     }
 
     protected abstract String streamId();
+
+    protected String cacheKey() {
+        return streamId();
+    }
 
     @Override
     protected R onOk(int status, HttpResponse response, BaasBox box) throws BaasException {
@@ -92,7 +96,7 @@ abstract class AsyncStream<R> extends NetworkTask<R> {
             in = BaasStream.getInput(entity);
             int read = 0;
             
-            cacheStream = box.mCache.beginStream(streamId());
+            cacheStream = box.mCache.beginStream(cacheKey());
             
             dataStream.startData(streamId(),contentLength,contentType);
 

--- a/library/src/main/java/com/baasbox/android/BaasFile.java
+++ b/library/src/main/java/com/baasbox/android/BaasFile.java
@@ -780,6 +780,7 @@ public class BaasFile extends BaasObject implements Parcelable{
 
     private static class FileStream<R> extends AsyncStream<R> {
         private final String id;
+        private final String cacheKey;
         private HttpRequest request;
 
         protected FileStream(BaasBox box, String id, String sizeSpec, int sizeId, int flags, DataStreamHandler<R> dataStream, BaasHandler<R> handler) {
@@ -788,8 +789,12 @@ public class BaasFile extends BaasObject implements Parcelable{
             RequestFactory.Param param = null;
             if (sizeSpec != null) {
                 param = new RequestFactory.Param("resize", sizeSpec);
+                this.cacheKey = id + "_" + sizeSpec.replace("<=", "lte");
             } else if (sizeId >= 0) {
                 param = new RequestFactory.Param("sizeId", Integer.toString(sizeId));
+                this.cacheKey = id + "_" + sizeId;
+            } else {
+                cacheKey = id;
             }
             String endpoint = box.requestFactory.getEndpoint("file/{}", id);
             if (param != null) {
@@ -802,6 +807,11 @@ public class BaasFile extends BaasObject implements Parcelable{
         @Override
         protected String streamId() {
             return id;
+        }
+
+        @Override
+        protected String cacheKey() {
+            return cacheKey;
         }
 
         @Override


### PR DESCRIPTION
fixes #43 

I'm not quite sure if line 792 of BaasFile.java is sufficient, though. There may be other valid characters for sizeSpec that are invalid as cache keys, and would need to be converted in the same way. Please advise.
